### PR TITLE
Fix client deconnection

### DIFF
--- a/src/httpserver/httpmessage.c
+++ b/src/httpserver/httpmessage.c
@@ -606,7 +606,8 @@ static int _httpmessage_parsepreheader(http_message_t *message, buffer_t *data)
 		 * uri buffer may be change during an extension
 		 */
 		message->query = strchr(message->uri->data, '?');
-		warn("new request %s %s from %p", message->method->key, message->uri->data, message->client);
+		const char *service = httpserver_INFO(httpclient_server(message->client), "service");
+		warn("new request %s %s from \"%s\" service", message->method->key, message->uri->data, service);
 	}
 	else if (message->uri == NULL)
 	{

--- a/src/httpserver/httpserver.c
+++ b/src/httpserver/httpserver.c
@@ -860,6 +860,11 @@ const char *httpserver_INFO(http_server_t *server, const char *key)
 	else if (!strcasecmp(key, "service"))
 	{
 		value = server->config->service;
+		if ( value == NULL)
+		{
+			snprintf(service, NI_MAXSERV, "%d", server->protocol_ops->default_port);
+			value = service;
+		}
 	}
 	else if (!strcasecmp(key, "software"))
 	{
@@ -888,11 +893,6 @@ const char *httpserver_INFO(http_server_t *server, const char *key)
 			}
 		}
 		value = server->methods_storage->data;
-	}
-	else if (!strcasecmp(key, "service"))
-	{
-		snprintf(service, NI_MAXSERV, "%d", server->protocol_ops->default_port);
-		value = service;
 	}
 	else if (!strcasecmp(key, "secure"))
 	{


### PR DESCRIPTION
fix the end of the first request in tls communication.
 - the end of the request checks new data in tls buffer and returns EAGAIN error
 - the EAGAIN error means that no data are still available but may be in the future.
 - the client process fells in error and close the communication, while the first request is not completed.

The patch push the client in WAITING mode after EAGAIN error, and continues the current request.